### PR TITLE
Remove excessive use of GC via system property

### DIFF
--- a/src/main/java/com/jpetrak/gate/stringannotation/extendedgazetteer/GazetteerBase.java
+++ b/src/main/java/com/jpetrak/gate/stringannotation/extendedgazetteer/GazetteerBase.java
@@ -123,20 +123,6 @@ public abstract class GazetteerBase extends AbstractLanguageAnalyser implements 
     }
   }
 
-  protected Boolean profile;
-
-  @CreoleParameter(
-        comment = "If enabled the PR will display information on memory usage etc.",
-        defaultValue = "false"
-  )
-  public void setProfile(Boolean profile) {
-     this.profile = profile;
-  }
-
-  public Boolean getProfile() {
-     return profile;
-  }
-
   public String getGazetteerFeatureSeparator() {
     return gazetteerFeatureSeparator;
   }
@@ -201,6 +187,8 @@ public abstract class GazetteerBase extends AbstractLanguageAnalyser implements 
     String uniqueGazStoreKey = genUniqueGazStoreKey();
     logger.info("Creating gazetteer for " + getConfigFileURL());
 
+    boolean profile = (System.getProperty("com.jpetrak.gate.stringannotation.profile") != null);
+
     long startTime = 0, before = 0;
 
     if (profile) {
@@ -246,6 +234,8 @@ public abstract class GazetteerBase extends AbstractLanguageAnalyser implements 
     logger.info("Replacing gazetteer for " + getConfigFileURL());
 
     long startTime = 0, before = 0;
+
+    boolean profile = (System.getProperty("com.jpetrak.gate.stringannotation.profile") != null);
 
     if (profile) {
        System.gc();

--- a/src/main/java/com/jpetrak/gate/stringannotation/extendedgazetteer/trie/StoreStates.java
+++ b/src/main/java/com/jpetrak/gate/stringannotation/extendedgazetteer/trie/StoreStates.java
@@ -91,16 +91,27 @@ public class StoreStates implements Serializable {
       if(logger==null) {
         logger = Logger.getLogger(this.getClass().getName());
       }
+
+      boolean profile = (System.getProperty("com.jpetrak.gate.stringannotation.profile") != null);
+
       logger.info("Compacting states");
-      System.gc();
-      long startTime = System.currentTimeMillis();
-      long before = ManagementFactory.getMemoryMXBean().getHeapMemoryUsage().getUsed();
+      long startTime = 0, before = 0;
+
+      if (profile) {
+         System.gc();
+         startTime = System.currentTimeMillis();
+         before = ManagementFactory.getMemoryMXBean().getHeapMemoryUsage().getUsed();
+      }
+
       charMapStore = new StoreCharMapPhase2(charMapStore);
-      long endTime = System.currentTimeMillis();
-      long after = ManagementFactory.getMemoryMXBean().getHeapMemoryUsage().getUsed();
-      logger.info("Compacting finished in (secs):        "+((endTime-startTime)/1000.0));
-      logger.info("Heap memory increase (estimate,MB):   "+
-        String.format("%01.3f", ((after-before)/(1024.0*1024.0))));
+
+      if (profile) {
+         long endTime = System.currentTimeMillis();
+         long after = ManagementFactory.getMemoryMXBean().getHeapMemoryUsage().getUsed();
+         logger.info("Compacting finished in (secs):        "+((endTime-startTime)/1000.0));
+         logger.info("Heap memory increase (estimate,MB):   "+
+           String.format("%01.3f", ((after-before)/(1024.0*1024.0))));
+      }
     }
   }
   


### PR DESCRIPTION
Hide all explicit uses of GC in the code behind a system property. This means in normal usage there won't be a huge slow down due to the GC calls. If you want to profile memory consumption during development then set the system property `com.jpetrak.gate.stringannotation.profile` to a none null value.